### PR TITLE
Make EncryptionKey parameter optional

### DIFF
--- a/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsBackupShare.ps1
+++ b/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsBackupShare.ps1
@@ -89,9 +89,9 @@ function Set-AzsBackupShare {
         [securestring]
         $Password,
 
-        [Parameter(Mandatory = $true, ParameterSetName = 'ResourceId')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'ResourceId')]
         [Parameter(Mandatory = $false, ParameterSetName = 'InputObject')]
-        [Parameter(Mandatory = $true, ParameterSetName = 'Update')]
+        [Parameter(Mandatory = $false, ParameterSetName = 'Update')]
         [ValidateNotNull()]
         [securestring]
         $EncryptionKey,


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Make EncryptionKey parameter optional

## Checklist

- [ ] I have read the [_Submitting Changes_](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md)
- [ ] The title of the PR is clear and informative
- [ ] The appropriate [change log has been updated](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md#updating-the-change-log)
- [ ] The PR does not introduce [breaking changes](https://github.com/Azure/azure-powershell/blob/preview/documentation/breaking-changes/breaking-changes-definition.md)
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] For public API changes to cmdlets:
    - [ ] the changes have gone through a [cmdlet design review](https://github.com/Azure/azure-powershell-cmdlet-review-pr)
    - [ ] the cmdlet markdown files were [generated using the `platyPS` module](https://github.com/Azure/azure-powershell/blob/preview/documentation/development-docs/help-generation.md)
