### PR TITLE
Fix InputObject param set when optional parameters not provided

### DIFF
--- a/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsBackupShare.ps1
+++ b/src/StackAdmin/Azs.Backup.Admin/Module/Azs.Backup.Admin/Generated.PowerShell.Commands/SwaggerPathCommands/Set-AzsBackupShare.ps1
@@ -161,10 +161,25 @@ function Set-AzsBackupShare {
                     $InputObject = Get-AzsBackupLocation -ResourceGroupName $ResourceGroupName -Location $Location
                 }
 
-                $InputObject.Path = $BackupShare
-                $InputObject.UserName = $Username
-                $InputObject.Password = ConvertTo-String -SecureString $Password
-                $InputObject.EncryptionKeyBase64 = ConvertTo-String $EncryptionKey
+                if ($PSBoundParameters.ContainsKey('BackupShare'))
+                {
+                    $InputObject.Path = $BackupShare
+                }
+
+                if ($PSBoundParameters.ContainsKey('Username'))
+                {
+                    $InputObject.UserName = $Username
+                }
+
+                if ($PSBoundParameters.ContainsKey('Password'))
+                {
+                    $InputObject.Password = ConvertTo-String -SecureString $Password
+                }
+
+                if ($PSBoundParameters.ContainsKey('EncryptionKey'))
+                {
+                    $InputObject.EncryptionKeyBase64 = ConvertTo-String $EncryptionKey
+                }
 
                 Write-Verbose -Message 'Performing operation update on $BackupAdminClient.'
                 $TaskResult = $BackupAdminClient.BackupLocations.UpdateWithHttpMessagesAsync($ResourceGroupName, $Location, $InputObject)


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Fix InputObject parameter set when optional parameters not provided

## Checklist

- [ ] I have read the [_Submitting Changes_](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md)
- [ ] The title of the PR is clear and informative
- [ ] The appropriate [change log has been updated](https://github.com/Azure/azure-powershell/blob/preview/CONTRIBUTING.md#updating-the-change-log)
- [ ] The PR does not introduce [breaking changes](https://github.com/Azure/azure-powershell/blob/preview/documentation/breaking-changes/breaking-changes-definition.md)
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] For public API changes to cmdlets:
    - [ ] the changes have gone through a [cmdlet design review](https://github.com/Azure/azure-powershell-cmdlet-review-pr)
    - [ ] the cmdlet markdown files were [generated using the `platyPS` module](https://github.com/Azure/azure-powershell/blob/preview/documentation/development-docs/help-generation.md)
